### PR TITLE
Optimisations and improvements

### DIFF
--- a/EmbyArrSync.py
+++ b/EmbyArrSync.py
@@ -322,6 +322,8 @@ def main():
                 BLACKLISTED_MOVIES.append(item['Name'])  # Add the Name to blacklisted Movies (Fall back for if path misses something)
                 print(f"Favorite Series: {item['Name']} and adding to blacklisted TV Shows")
                 continue
+    if not IGNORE_FAVOURITES:
+        print("Ignore Favourites set to false, WARNING FAVOURITES WILL BE HANDLED BY THE SCRIPT.")
     # Print statement for Handle TV = False
     if not HANDLE_TV:
         print("Handling of TV shows is disabled, Skipping to Movies.")

--- a/EmbyArrSync.py
+++ b/EmbyArrSync.py
@@ -300,11 +300,15 @@ def main():
     if watched_series:
         for item in watched_series:
             if item['UserData']['IsFavorite'] and item['Type'] == 'Series' and HANDLE_TV:
+                BLACKLISTED_PATHS.append(item['Path'])  # Add the path to blacklisted paths (should capture everything)
                 print(f"Favorite Series: {item['Name']} and adding {item['Path']} to blacklisted paths")
-                BLACKLISTED_PATHS.append(item['Path'])  # Add the path to blacklisted paths
+                BLACKLISTED_TV_SHOWS.append(item['Name'])  # Add the Name to blacklisted Movies (Fall back for if path misses something)
+                print(f"Favorite Series: {item['Name']} and adding to blacklisted TV Shows")
             elif item['UserData']['IsFavorite'] and item['Type'] == 'Movie' and HANDLE_MOVIES:
+                BLACKLISTED_PATHS.append(item['Path'])  # Add the path to blacklisted paths (should capture everything)
                 print(f"Favorite Movie: {item['Name']} and adding {item['Path']} to blacklisted paths")
-                BLACKLISTED_PATHS.append(item['Path'])  # Add the path to blacklisted paths
+                BLACKLISTED_MOVIES.append(item['Name'])  # Add the Name to blacklisted Movies (Fall back for if path misses something)
+                print(f"Favorite Series: {item['Name']} and adding to blacklisted TV Shows")
                 continue
     # Print statement for Handle TV = False
     if not HANDLE_TV:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Login to Emby, go to Dashboard and then to users, select the user you want the s
 
 Open EmbyArrSync.env in the config Folder with your prefered text editor and Replace the placeholders with the correct variables
 
+Warning setting "IGNORE_FAVOURITES" to False means the script will run on items that are favourited in emby, Setting to true means items Favourited in emby will be blacklisted and ignored by the script
+
 if installed in its own folder in /opt
 
 ```
@@ -66,6 +68,7 @@ HANDLE_TV = True # Set to false to disable the script from touching TV shows
 HANDLE_MOVIES = True # Set to false to disable the script from touching Movies shows
 TV_DELETE = True # Set to false to disable the script from Deleting TV shows
 MOVIE_DELETE = True # Set to false to disable the script from Deleting Movies shows
+IGNORE_FAVOURITES = True # Set to True if you want the script to ignore items that are marked as favourites in emby (Not Unmonitor and Not Delete)
 
 
 # Sonarr API details

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Open EmbyArrSync.env in the config Folder with your prefered text editor and Rep
 
 Warning setting "IGNORE_FAVOURITES" to False means the script will run on items that are favourited in emby, Setting to true means items Favourited in emby will be blacklisted and ignored by the script
 
+It is reccomended to lower the limit after first run, this limit is just as high as possible so that first run gets as many watched shows as possible.
+
 if installed in its own folder in /opt
 
 ```

--- a/config/EmbyArrSync.env
+++ b/config/EmbyArrSync.env
@@ -3,7 +3,7 @@ HANDLE_TV = True # Set to false to disable the script from touching TV shows
 HANDLE_MOVIES = True # Set to false to disable the script from touching Movies shows
 TV_DELETE = True # Set to false to disable the script from Deleting TV shows
 MOVIE_DELETE = True # Set to false to disable the script from Deleting Movies shows
-IGNORE_FAVOURITES = True # Set to false to if you want the scipt to unmonitor and delete items that are marked as favourites in emby
+IGNORE_FAVOURITES = True # Set to True if you want the script to ignore items that are marked as favourites in emby (Not Unmonitor and Not Delete)
 
 # Sonarr API details
 SONARR_API_KEY = 'SONARR_API_KEY'

--- a/config/EmbyArrSync.env
+++ b/config/EmbyArrSync.env
@@ -1,9 +1,9 @@
-# TV and Movie Handling Logic
+# TV, Movie and Favourite Handling Logic
 HANDLE_TV = True # Set to false to disable the script from touching TV shows
 HANDLE_MOVIES = True # Set to false to disable the script from touching Movies shows
 TV_DELETE = True # Set to false to disable the script from Deleting TV shows
 MOVIE_DELETE = True # Set to false to disable the script from Deleting Movies shows
-
+IGNORE_FAVOURITES = True # Set to false to if you want the scipt to unmonitor and delete items that are marked as favourites in emby
 
 # Sonarr API details
 SONARR_API_KEY = 'SONARR_API_KEY'


### PR DESCRIPTION
Resolves #8
closes #8 
resolves #9 
closes #9 

Improved functionality of the Favourite handling, it now handles TV shows and movies separately and it now adds the series name to blacklisted TV Shows and movie Name to blacklisted movies along with the path to blacklisted paths for both, this wasn't necessary but was added as a fallback.

Added IGNORE_FAVOURITES as an env variable so people can set this to false if they want to disable the script ignoring/blacklisting favourites (Default behavior is true)

Improved the functions to get TVDB and TMDBID which are used by sonarr/radarr functions to find the correct show/movie, it will now check the items path for tvdbid-Number and tmdbid-Number which if you are following the recommended naming guides and are using sonarr/radarr to rename them then these should be found in the path, however if these aren't found in the path it will fallback to calling the TVDB and TMDB APIs to query them for the ID.

This was done to limit the possibility of getting the wrong ID and to limit the number of API calls made to TVDB and TMDB 